### PR TITLE
fix: remove unnecesary argument on aula09

### DIFF
--- a/aula09/src/Aula09.hs
+++ b/aula09/src/Aula09.hs
@@ -42,7 +42,7 @@ nameCorrectFixed s = (all isLetter' s) `implies` b
                    ord 'a' <= ord c' && ord c' <= ord 'z'
 
 sort1 :: [Int] -> [Int]
-sort1 []       0= []
+sort1 []       = []
 sort1 (x : xs) = insert1 x xs
 
 insert1 :: Int -> [Int] -> [Int]


### PR DESCRIPTION
This PR solves the stack build command execution for aula09
The current code is causing the following error:
`
error: Equations for ‘sort1’ have different numbers of arguments
      src/Aula09.hs:45:1-20
      src/Aula09.hs:46:1-29
     |
45 | sort1 []       0= []
     | ^^^^^^^^^^^^^^^^^^^^...

`
And that commit solves it.